### PR TITLE
dbmatcher init

### DIFF
--- a/internal/proxytag/matcher.go
+++ b/internal/proxytag/matcher.go
@@ -50,14 +50,19 @@ var (
 // processing.
 type Matcher func(string) (Match, error)
 
+// Matchcerobj is a hack wrapper to return dynamically generated functions from a method
+type Matcherobj struct {
+	Matcher Matcher
+}
+
 // Parse parses a message with a list of matchers and returns the
-func Parse(message string, matchers ...Matcher) (Match, error) {
-	if len(message) < 3 {
+func Parse(message string, matcherobjs ...Matcherobj) (Match, error) {
+	if len(message) < 2 {
 		return Match{}, ErrNoMatch
 	}
 
-	for _, mat := range matchers {
-		mm, merr := mat(message)
+	for _, matobj := range matcherobjs {
+		mm, merr := matobj.Matcher(message)
 		if merr != nil {
 			if merr == ErrNoMatch {
 				continue
@@ -70,4 +75,44 @@ func Parse(message string, matchers ...Matcher) (Match, error) {
 	}
 
 	return Match{}, ErrNoMatch
+}
+
+//this replaces the existing matchers (in message decoding, not sysmate init) by taking a db match and creating a wrapper for a Matcher that checks just for that
+func CreateMatcherobj(m Match) Matcherobj {
+	//the message is already assumed trimmed for Matcher purposes
+	switch method := m.Method; method {
+		case "Nameslash":
+			return &Matcherobj{
+				Matcher: func(message string) (Match, error) {
+					//check if name is there
+					if strings.HasPrefix(message, m.Name) {
+						message = strings.TrimSpace(message[len(m.Name):])
+						//then check if one of the separators is there
+						for _, sigil := range []string{`\`, `:`, `/`, '>'} {
+							if string.HasPrefix(message, sigil) {
+								//the rest trimmed is the message
+								m.Body = strings.TrimSpace(message[len(sigil):])
+								return m, nil
+							}
+						}
+					}
+					return m, ErrNoMatch						
+				}
+			}
+		case "Sigils", "HalfSigilStart", "HalfSigilEnd":
+			return &Matcherobj{
+				Matcher: func(message string) (Match, error) {
+					//check if there's the begin and end
+					if strings.HasPrefix(message, m.InitialSigil) && strings.HasSuffix(message, m.EndSigil) {
+						//the rest trimmed is the message
+						m.Body = strings.TrimSpace(message[len(m.InitialSigil):len(message)-len(m.EndSigil)])
+						return m, nil
+					} 
+					return m, ErrNoMatch
+				}
+			}
+		default:
+			// should never happen until new proxy methods are implemented
+			return &Matcherobj{}
+	}
 }


### PR DESCRIPTION
Changed so that, when decoding regular messages, it reads the sysmates first from db, and then checks only against the registered sigils, for more robust handling of messages.

I have no immediate way to compile this, much less test it, and this is my first time writing Go, so there's probably some typo or error somewhere. Hopefully the code+comments will convey the intent if there's any fixes to make.

I have no earthly idea how to make tests for the new code, so forgive me this. Ideally, the tests could consist of:

- assembling some `Match`es  
- creating a `[]Matcherobj` from them through `CreateMatcherobj`  
- try parsing messages by `Parse(testmsg, matcherobjs...)` and see if it comes out correctly