### PR TITLE
New proxy matcher logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM xena/go:1.11.1 AS build
 ENV GOPROXY https://cache.greedo.xeserv.us
 WORKDIR /ventriloquist
+RUN apk add --no-cache ghc cabal wget \
+ && cabal update \
+ && cabal install aeson bytestring vector text \
 COPY . .
 RUN apk add --no-cache build-base \
- && GOBIN=/usr/local/bin go install ./cmd/ventriloquist
+ && GOBIN=/usr/local/bin go install ./cmd/ventriloquist \
+ && ghc -O2 -o /usr/local/bin/proxy-matcher internal/proxytag/Matcher.hs
 
 FROM xena/alpine
 COPY --from=build /usr/local/bin/ventriloquist /usr/local/bin/ventriloquist
+COPY --from=build /usr/local/bin/proxy-matcher /usr/local/bin/proxy-matcher
+RUN apk add --no-cache so:libgmp.so.10 so:libffi.so.6
 VOLUME /data
 ENV DB_PATH /data/tulpas.db
 CMD ["/usr/local/bin/ventriloquist"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM xena/go:1.11.1 AS build
 ENV GOPROXY https://cache.greedo.xeserv.us
-WORKDIR /ventriloquist
-RUN apk add --no-cache ghc cabal wget \
+RUN apk add --no-cache ghc cabal wget build-base \
  && cabal update \
- && cabal install aeson bytestring vector text \
+ && cabal install aeson bytestring vector text
+WORKDIR /ventriloquist
 COPY . .
 RUN apk add --no-cache build-base \
  && GOBIN=/usr/local/bin go install ./cmd/ventriloquist \

--- a/cmd/ventriloquist/database.go
+++ b/cmd/ventriloquist/database.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -139,6 +140,86 @@ func (d DB) FindSystemmateByMatch(coreDiscordID string, m proxytag.Match) (Syste
 	}
 
 	return Systemmate{}, errors.New("database: systemmate not found")
+}
+
+func (d DB) FindSystemmateByMessage(coreDiscordID string, message string) (Systemmate, string, error) {
+	sms, err := d.FindSystemmates(coreDiscordID)
+	if err != nil {
+		return Systemmate{}, "", err
+	}
+
+	matchers := make([]map[string]interface{}, len(sms))
+
+	for i, sm := range sms {
+		match := sm.Match
+		var prefix, suffix string
+		if match.Method == "Nameslash" {
+			prefix = match.Name + "\\"
+		} else if match.Method == "Sigils" {
+			prefix = match.InitialSigil
+			suffix = match.EndSigil
+		} else if match.Method == "HalfSigilStart" {
+			prefix = match.InitialSigil
+		} else {
+			// Dirty hack to create a matcher that won't match anything
+			prefix = "\x00"
+			suffix = "\x00"
+		}
+		if suffix == "" {
+			matchers[i] = map[string]interface{}{
+				"matcherPrefix": prefix,
+				"matcherSuffix": suffix,
+				"matcherSystemMate": sm.Name,
+			}
+		} else {
+			matchers[i] = map[string]interface{}{
+				"matcherPrefix": prefix,
+				"matcherSystemMate": sm.Name,
+			}
+
+		}
+	}
+
+	matcherMessage := map[string]interface{}{
+		"messageBody": message,
+		"messageMatchers": matchers,
+	}
+
+	cmd := exec.Command("proxy-matcher")
+	cmdStdin, err := cmd.StdinPipe()
+	if err != nil {
+		return Systemmate{}, "", err
+	}
+	err = json.NewEncoder(cmdStdin).Encode(matcherMessage)
+	if err != nil {
+		return Systemmate{}, "", err
+	}
+	cmdStdin.Close()
+	cmdStdout, err := cmd.Output()
+	if err != nil {
+		return Systemmate{}, "", err
+	}
+	var matcherResponse map[string]interface{}
+	err = json.Unmarshal(cmdStdout, &matcherResponse)
+	if err != nil {
+		return Systemmate{}, "", err
+	}
+
+	if matcherResponse["responseError"] != nil || matcherResponse["responseMatch"] == nil {
+		return Systemmate{}, "", errors.New("database: systemmate not found")
+	}
+
+	match := matcherResponse["responseMatch"].(map[string]interface{})
+	matchSystemMate := match["matchSystemMate"].(string)
+	matchBody := match["matchBody"].(string)
+
+	for _, sm := range sms {
+		if sm.Name == matchSystemMate {
+			return sm, matchBody, nil
+		}
+	}
+
+	return Systemmate{}, "", errors.New("database: systemmate not found")
 }
 
 func (d DB) NukeSystem(coreDiscordID string) error {

--- a/cmd/ventriloquist/database.go
+++ b/cmd/ventriloquist/database.go
@@ -165,7 +165,7 @@ func (d DB) FindSystemmateByMessage(coreDiscordID string, message string) (Syste
 			prefix = "\x00"
 			suffix = "\x00"
 		}
-		if suffix == "" {
+		if suffix != "" {
 			matchers[i] = map[string]interface{}{
 				"matcherPrefix": prefix,
 				"matcherSuffix": suffix,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,12 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
 
+  logging:
+    image: artemis/minimal-logging
+    restart: always
+    volumes:
+      - minimal-logging:/app/logs
+
 volumes:
   data:
   influxdb-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,12 +33,6 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
 
-  logging:
-    image: artemis/minimal-logging
-    restart: always
-    volumes:
-      - ./minimal-logging:/app/logs
-
 volumes:
   data:
   influxdb-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     image: artemis/minimal-logging
     restart: always
     volumes:
-      - minimal-logging:/app/logs
+      - ./minimal-logging:/app/logs
 
 volumes:
   data:

--- a/internal/proxytag/Matcher.hs
+++ b/internal/proxytag/Matcher.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Aeson as Aeson
+import Data.Vector (Vector)
+import GHC.Generics
+import qualified Data.ByteString.Lazy as ByteString.Lazy
+import Data.Monoid
+
+main :: IO ()
+main = do
+  input <- ByteString.Lazy.getContents
+  let response =
+        case Aeson.decode input of
+          Nothing ->
+            Response
+              { responseError = Just "error: could not decode message json"
+              , responseMatch = Nothing
+              }
+          Just msg ->
+            Response {responseError = Nothing, responseMatch = messageMatch msg}
+      output = Aeson.encode response
+  ByteString.Lazy.putStr output
+
+data Message = Message
+  { messageBody :: Text
+  , messageMatchers :: Vector Matcher
+  } deriving (Eq, Read, Show, Generic)
+
+instance Aeson.ToJSON Message where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+
+instance Aeson.FromJSON Message
+
+data Matcher = Matcher
+  { matcherPrefix :: Text
+  , matcherSuffix :: Maybe Text
+  , matcherSystemMate :: Text
+  } deriving (Eq, Read, Show, Generic)
+
+instance Aeson.ToJSON Matcher where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+
+instance Aeson.FromJSON Matcher
+
+data Match = Match
+  { matchPrefix :: Text
+  , matchSuffix :: Maybe Text
+  , matchBody :: Text
+  , matchSystemMate :: Text
+  } deriving (Eq, Read, Show, Generic)
+
+instance Aeson.ToJSON Match where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+
+instance Aeson.FromJSON Match
+
+data Response = Response
+  { responseError :: Maybe Text
+  , responseMatch :: Maybe Match
+  } deriving (Eq, Read, Show, Generic)
+
+instance Aeson.ToJSON Response where
+  toEncoding = Aeson.genericToEncoding Aeson.defaultOptions
+
+instance Aeson.FromJSON Response
+
+matchRaw :: Matcher -> Text -> Maybe Match
+matchRaw matcher body = do
+  withoutPrefix <- Text.stripPrefix (matcherPrefix matcher) body
+  let withoutSuffix = do
+        suffix <- matcherSuffix matcher
+        Text.stripSuffix suffix withoutPrefix
+  case withoutSuffix of
+    Nothing ->
+      Just
+        Match
+          { matchPrefix = matcherPrefix matcher
+          , matchSuffix = Nothing
+          , matchBody = withoutPrefix
+          , matchSystemMate = matcherSystemMate matcher
+          }
+    Just b ->
+      Just
+        Match
+          { matchPrefix = matcherPrefix matcher
+          , matchSuffix = matcherSuffix matcher
+          , matchBody = b
+          , matchSystemMate = matcherSystemMate matcher
+          }
+
+-- This is just matchRaw but it runs Text.strip on the input and output
+match :: Matcher -> Text -> Maybe Match
+match matcher body = do
+  result <- matchRaw matcher (Text.strip body)
+  Just (result {matchBody = Text.strip (matchBody result)})
+
+messageMatch :: Message -> Maybe Match
+messageMatch message =
+  getAlt
+    (foldMap
+       (\matcher -> Alt (match matcher (messageBody message)))
+       (messageMatchers message))
+
+detectNamePrefixMatcher :: Text -> Maybe Matcher
+detectNamePrefixMatcher msg =
+  case Text.splitOn "\\" msg of
+    [prefix, _] ->
+      Just
+        Matcher
+          { matcherPrefix = Text.strip prefix
+          , matcherSuffix = Nothing
+          , matcherSystemMate = ""
+          }
+    _ -> Nothing
+  
+
+detectSigilsMatcher :: Text -> Maybe Matcher
+detectSigilsMatcher = detectGenericMatcher
+
+detectGenericMatcher :: Text -> Maybe Matcher
+detectGenericMatcher msg =
+  case Text.splitOn "text" msg of
+    [prefix, _] ->
+      Just
+        Matcher
+          { matcherPrefix = Text.strip prefix
+          , matcherSuffix = Nothing
+          , matcherSystemMate = ""
+          }
+    [prefix, _, suffix] ->
+      Just
+        Matcher
+          { matcherPrefix = Text.strip prefix
+          , matcherSuffix = Just (Text.strip suffix)
+          , matcherSystemMate = ""
+          }
+    _ -> Nothing
+
+detectMatcher :: Text -> Maybe Matcher
+detectMatcher msg =
+  getAlt
+    (foldMap
+       (\f -> Alt (f msg))
+       [detectNamePrefixMatcher, detectSigilsMatcher, detectGenericMatcher])


### PR DESCRIPTION
Currently a problem exists where the HalfSigilStart proxy method is not correctly detected for messages ending in certain symbols. This is a stopgap fix for these issues.

## Small Example

Let a system member exist with a proxy sigil of `{`.

Previously, `{test~` would fail to match against this system member, and not be proxied.

Now, `{test~` will properly proxy as `test~`.

## Known Issues

- Users may still register `HalfSigilEnd` matchers, but these do not actually do anything.
- Users may register multiple matchers with the same `InitialSigil`. This silently only allows the first-registered matcher to work.
- The new matcher logic is in a haskell file and executed as an external binary. The logic is very simple and should be written in Go instead.
- The old matcher logic is still used for registering proxies.
- The old matcher data structure is stored in the bot database.

## Extensive Examples

I am user.
I `;chproxy Faith [text]`

I expect `[text.` to proxy as `text.`
I expect `[text.]` to proxy as `text.`
I expect `[text.~` to proxy as `text.~`
I expect `text]` to *not* proxy.


I `;chproxy Faith [text`

I expect `[text.` to proxy as `text.`
I expect `[text.]` to proxy as `text.]`
I expect `[text.~` to proxy as `text.~`
I expect `text]` to *not* proxy.


I `;chproxy Faith [text~`

I expect `[text.` to proxy as `text.`
I expect `[text.]` to proxy as `text.]`
I expect `[text.~` to proxy as `text.`
I expect `text~` to *not* proxy.


I `;chproxy Diana [text}`. I expect an error informing me that `[` is already in use as a prefix symbol by Faith, or that Faith's proxy has been removed.

I do not expect the bot to be able to handle Faith proxying as `[text~` and Diana proxying as `[text}` under the same ventriloquist account association.